### PR TITLE
fix(site): update homepage and typography

### DIFF
--- a/assets/css/extended/15-typography.css
+++ b/assets/css/extended/15-typography.css
@@ -23,6 +23,10 @@ body, button, input, select, textarea {
     font-family: var(--font-body);
 }
 
+body {
+    font-size: var(--text-base);
+}
+
 code, kbd, pre, samp,
 .post-content code,
 .post-content pre,

--- a/assets/css/extended/50-code.css
+++ b/assets/css/extended/50-code.css
@@ -117,7 +117,7 @@ html[data-theme="light"] .code-window {
 .md-content .code-window pre code {
     display: block;
     margin: 0;
-    padding: 0 !important;
+    padding: 0 5.25rem 0 1.35rem !important;
     color: inherit;
     background: transparent !important;
     border-radius: 0;
@@ -126,7 +126,12 @@ html[data-theme="light"] .code-window {
     word-break: normal;
 }
 
-.code-window .shiki-code {
+.md-content .code-window pre code.is-highlighted {
+    padding: 0 !important;
+}
+
+.code-window .shiki-code,
+.code-window .code-block-code {
     min-width: max-content;
     color: var(--primary);
     font-size: 0.95rem;
@@ -173,6 +178,110 @@ html[data-theme="dark"] .code-window .shiki-code .tok {
     color: var(--shiki-dark) !important;
     font-style: var(--shiki-dark-font-style) !important;
     text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
+.code-window .chroma-code {
+    --chroma-text: var(--ctp-mocha-text);
+    --chroma-keyword: var(--ctp-mocha-red);
+    --chroma-name: var(--ctp-mocha-mauve);
+    --chroma-type: var(--ctp-mocha-yellow);
+    --chroma-string: var(--ctp-mocha-green);
+    --chroma-number: var(--ctp-mocha-blue);
+    --chroma-comment: var(--ctp-mocha-overlay1);
+    --chroma-operator: var(--ctp-mocha-red);
+    --chroma-punctuation: var(--ctp-mocha-subtext0);
+
+    color: var(--chroma-text);
+}
+
+html[data-theme="light"] .code-window .chroma-code {
+    --chroma-text: var(--ctp-latte-text);
+    --chroma-keyword: var(--ctp-latte-red);
+    --chroma-name: var(--ctp-latte-mauve);
+    --chroma-type: var(--ctp-latte-yellow);
+    --chroma-string: var(--ctp-latte-green);
+    --chroma-number: var(--ctp-latte-blue);
+    --chroma-comment: var(--ctp-latte-subtext0);
+    --chroma-operator: var(--ctp-latte-red);
+    --chroma-punctuation: var(--ctp-latte-subtext1);
+}
+
+.code-window .chroma-code .k,
+.code-window .chroma-code .kc,
+.code-window .chroma-code .kd,
+.code-window .chroma-code .kn,
+.code-window .chroma-code .kp,
+.code-window .chroma-code .kr,
+.code-window .chroma-code .kt {
+    color: var(--chroma-keyword);
+    font-weight: 650;
+}
+
+.code-window .chroma-code .nc,
+.code-window .chroma-code .nd,
+.code-window .chroma-code .ne,
+.code-window .chroma-code .nf,
+.code-window .chroma-code .nt,
+.code-window .chroma-code .nx {
+    color: var(--chroma-name);
+    font-weight: 650;
+}
+
+.code-window .chroma-code .nb,
+.code-window .chroma-code .no,
+.code-window .chroma-code .nv,
+.code-window .chroma-code .vc,
+.code-window .chroma-code .vg,
+.code-window .chroma-code .vi {
+    color: var(--chroma-text);
+}
+
+.code-window .chroma-code .s,
+.code-window .chroma-code .sa,
+.code-window .chroma-code .sb,
+.code-window .chroma-code .sc,
+.code-window .chroma-code .dl,
+.code-window .chroma-code .sd,
+.code-window .chroma-code .s2,
+.code-window .chroma-code .se,
+.code-window .chroma-code .sh,
+.code-window .chroma-code .si,
+.code-window .chroma-code .sx,
+.code-window .chroma-code .sr,
+.code-window .chroma-code .s1,
+.code-window .chroma-code .ss {
+    color: var(--chroma-string);
+}
+
+.code-window .chroma-code .m,
+.code-window .chroma-code .mb,
+.code-window .chroma-code .mf,
+.code-window .chroma-code .mh,
+.code-window .chroma-code .mi,
+.code-window .chroma-code .il,
+.code-window .chroma-code .mo {
+    color: var(--chroma-number);
+}
+
+.code-window .chroma-code .c,
+.code-window .chroma-code .ch,
+.code-window .chroma-code .cm,
+.code-window .chroma-code .c1,
+.code-window .chroma-code .cs,
+.code-window .chroma-code .cp,
+.code-window .chroma-code .cpf {
+    color: var(--chroma-comment);
+    font-style: italic;
+}
+
+.code-window .chroma-code .o,
+.code-window .chroma-code .ow {
+    color: var(--chroma-operator);
+    font-weight: 650;
+}
+
+.code-window .chroma-code .p {
+    color: var(--chroma-punctuation);
 }
 
 html[data-theme="light"][data-syntax="cb"] .code-window {
@@ -242,6 +351,18 @@ html[data-syntax="cb"] .code-window .shiki-code .tok-punctuation {
     color: var(--cb-code-punctuation) !important;
 }
 
+html[data-syntax="cb"] .code-window .chroma-code {
+    --chroma-text: var(--cb-code-text);
+    --chroma-keyword: var(--cb-code-keyword);
+    --chroma-name: var(--cb-code-entity);
+    --chroma-type: var(--cb-code-support);
+    --chroma-string: var(--cb-code-string);
+    --chroma-number: var(--cb-code-constant);
+    --chroma-comment: var(--cb-code-comment);
+    --chroma-operator: var(--cb-code-operator);
+    --chroma-punctuation: var(--cb-code-punctuation);
+}
+
 .code-window .copy-code {
     position: absolute;
     top: 0.75rem;
@@ -302,6 +423,10 @@ html[data-syntax="cb"] .code-window .shiki-code .tok-punctuation {
 }
 
 @media (max-width: 640px) {
+    .md-content .code-window pre code {
+        padding-right: 4.25rem !important;
+    }
+
     .code-window .line-code {
         padding-right: 4.25rem !important;
     }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -19,7 +19,7 @@ minify:
 params:
   env: production # to enable google analytics, opengraph, twitter-cards and schema.
   title: Gus Machado
-  description: "Data-focussed Software Engineer, based in London, UK, currently a Data Engineer at Meta"
+  description: "Staff Software Engineer at Personio, based in London, UK, building distributed data systems, lakehouse infrastructure, and near-real-time data platforms."
   keywords: [Blog, Portfolio, PaperMod]
   author: Gus Machado
   images: ["/img/avatar.png"]
@@ -70,8 +70,8 @@ params:
   # profile-mode
   profileMode:
     enabled: true # needs to be explicitly set
-    title: Hi, I'm Gus!
-    subtitle: Software engineer from London, UK. Passionate about data processing systems and AI/ML. Working as a Data Engineer at [Meta](https://meta.com). Likes to unwind by playing guitar, games and pointing a camera at pretty things. Owns a borderline-illegal amount of coffee paraphernalia. ☕️
+    title: Hi, I’m Gus!
+    subtitle: Software Engineer based in London, UK. I build distributed data systems, lakehouse infrastructure, and near-real-time data platforms. Making data fast, correct, and boring. Currently Staff Software Engineer at [Personio](https://www.personio.com). Previously [WhatsApp](https://www.whatsapp.com)/[Meta](https://meta.com).<br><br>Away from keyboards, I’m usually playing guitar, playing games, taking photos, or making coffee more complicated than it needs to be. ☕️
     imageUrl: "/img/avatar.png"
     imageWidth: 250
     imageHeight: 250

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -16,7 +16,14 @@
   {{- end }}
   <div class="code-frame">
     <span class="code-lang">{{ $lang }}</span>
+    {{- if hugo.IsServer }}
+    {{- $opts := merge .Options (dict "lineNos" false "noClasses" false) -}}
+    {{- $highlighted := transform.HighlightCodeBlock . $opts -}}
+    {{- $rawCode := replace ($code | urlquery) "+" "%20" -}}
+    <pre class="shiki-source" tabindex="0"><code class="code-block-code chroma-code language-{{ $lang }}" data-lang="{{ $lang }}" data-raw-code="{{ $rawCode }}">{{ $highlighted.Inner }}</code></pre>
+    {{- else }}
     <pre class="shiki-source" tabindex="0"><code class="shiki-code language-{{ $lang }}" data-lang="{{ $lang }}">{{ $code | htmlEscape | safeHTML }}</code></pre>
+    {{- end }}
   </div>
 </figure>
 {{- end -}}

--- a/scripts/check-review-regressions.mjs
+++ b/scripts/check-review-regressions.mjs
@@ -144,6 +144,33 @@ async function checkCodeCopyFallbackKeepsLineBreaks() {
   assert.equal(copied, "first\nsecond");
 }
 
+async function checkBodyFontSizeUsesBaseToken() {
+  const source = await fs.readFile(path.join(ROOT, "assets/css/extended/15-typography.css"), "utf8");
+
+  assert.match(
+    source,
+    /body\s*\{[^}]*font-size:\s*var\(--text-base\)/s,
+    "body copy should stay pinned to the 16px base token",
+  );
+}
+
+async function checkTypographyPageUsesShikiOutput() {
+  await run("bun", ["run", "build"]);
+
+  const htmlPath = path.join(ROOT, "public/typography/index.html");
+  const html = await fs.readFile(htmlPath, "utf8");
+
+  assert.match(
+    html,
+    /<code\b[^>]*class=["'][^"']*\bshiki-code\b[^"']*\bis-highlighted\b[^"']*["'][^>]*>/,
+    "typography code blocks should use the Shiki post-processed markup",
+  );
+  assert.match(html, /class=["']line-number["']/, "typography code blocks should render line numbers");
+  assert.match(html, /class=["']line-code["']/, "typography code blocks should wrap line contents");
+  assert.match(html, /\btok-keyword\b|\btok-entity\b/, "typography code blocks should include Shiki token classes");
+  assert.doesNotMatch(html, /\bchroma-code\b/, "production typography page should not use the Hugo-server fallback");
+}
+
 async function checkPostNavigationAndTocDepth() {
   const suffix = `${process.pid}-${Date.now()}`;
   const alpha = `review-regression-alpha-${suffix}`;
@@ -239,6 +266,8 @@ async function checkMalformedUrlsReturnBadRequest() {
 const checks = [
   ["share label resets after rapid clicks", checkShareLabelResetsAfterRapidClicks],
   ["code copy fallback keeps line breaks", checkCodeCopyFallbackKeepsLineBreaks],
+  ["body font size uses base token", checkBodyFontSizeUsesBaseToken],
+  ["typography page uses Shiki output", checkTypographyPageUsesShikiOutput],
   ["post navigation and Hugo TOC depth render", checkPostNavigationAndTocDepth],
   ["malformed URLs return a bad request", checkMalformedUrlsReturnBadRequest],
 ];

--- a/scripts/shiki-highlight.mjs
+++ b/scripts/shiki-highlight.mjs
@@ -49,6 +49,16 @@ function getAttribute(attrs, name) {
   return bare ? bare[1] : "";
 }
 
+function appendClass(attrs, className) {
+  return attrs.replace(/\bclass=(["'])([^"']*)\1/i, (_match, quote, classes) => {
+    const nextClasses = classes.split(/\s+/).includes(className)
+      ? classes
+      : `${classes} ${className}`;
+
+    return `class=${quote}${nextClasses}${quote}`;
+  });
+}
+
 function normalizeLang(lang) {
   const lower = (lang || "text").toLowerCase();
   return LANGUAGE_ALIASES.get(lower) || lower;
@@ -167,7 +177,8 @@ async function processFile(filePath) {
     const code = decodeHtml(escapedCode);
     const highlighted = await highlight(code, lang);
     const cleanAttrs = attrs.replace(/\sdata-raw-code=(["']).*?\1/i, "");
-    output += `<code${cleanAttrs} data-raw-code="${encodeURIComponent(code)}">${highlighted}</code>`;
+    const highlightedAttrs = appendClass(cleanAttrs, "is-highlighted");
+    output += `<code${highlightedAttrs} data-raw-code="${encodeURIComponent(code)}">${highlighted}</code>`;
     cursor = index + fullMatch.length;
     count += 1;
   }


### PR DESCRIPTION
## Summary

- Updates the homepage profile copy and metadata for the current Personio role.
- Pins body copy to the 16px base type token.
- Keeps the typography page on the Shiki post-processing path for normal builds.
- Adds a direct `hugo server` fallback so code blocks still have padding and syntax color before Bun post-processing runs.

## Checks

- `just check` passed
- Built `/typography/` browser probe: body and paragraph text computed at `16px`; 2 Shiki-highlighted blocks; 6 line numbers; 49 token spans
- Direct `hugo server` browser probe: body and paragraph text computed at `16px`; 2 Chroma fallback blocks with padding and syntax color
- Hugo still reports existing deprecation warnings for `.Language.LanguageDirection` and `.Language.LanguageCode`
