### PR TITLE
feat(content): add llms text outputs

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -22,7 +22,10 @@ params:
   description: "Staff Software Engineer at Personio, based in London, UK, building distributed data systems, lakehouse infrastructure, and near-real-time data platforms."
   keywords: [Blog, Portfolio, PaperMod]
   author: Gus Machado
+  mainSections: ["posts"]
   images: ["/img/avatar.png"]
+  photos:
+    pageSize: 6
   DateFormat: "January 2, 2006"
   defaultTheme: auto # dark, light
   disableThemeToggle: false
@@ -176,8 +179,32 @@ markup:
     renderer:
       unsafe: true # allow raw HTML in markdown (we author all content)
 
+# Custom output formats for machine-friendly content.
+# /llms.txt and /llms-full.txt follow https://llmstxt.org.
+# Per-page raw markdown is exposed as <page>/index.md.
+outputFormats:
+  llms:
+    mediaType: text/plain
+    baseName: llms
+    isPlainText: true
+    notAlternative: true
+  llmsfull:
+    mediaType: text/plain
+    baseName: llms-full
+    isPlainText: true
+    notAlternative: true
+  markdown:
+    mediaType: text/markdown
+    isPlainText: true
+    notAlternative: true
+
 outputs:
   home:
     - HTML
     - RSS
     - JSON # is necessary
+    - llms
+    - llmsfull
+  page:
+    - HTML
+    - markdown

--- a/layouts/home.llms.txt
+++ b/layouts/home.llms.txt
@@ -1,0 +1,28 @@
+{{- /* /llms.txt: curated machine-readable index. https://llmstxt.org */ -}}
+# {{ .Site.Title }}
+
+> {{ .Site.Params.description }}
+
+Machine-friendly index of {{ .Site.BaseURL }}. Each page also exposes its source markdown at `<page-url>/index.md`. A full inlined dump is available at {{ "llms-full.txt" | absURL }}.
+
+Usage policy: search and user-triggered AI browsing are welcome; training use is not granted. See {{ "robots.txt" | absURL }} for the formal signal.
+
+## Posts
+{{ range where .Site.RegularPages "Section" "posts" -}}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{ end }}
+## Pages
+{{ range where .Site.RegularPages "Section" "" -}}
+{{- if not (in (slice "search" "archives") .File.ContentBaseName) -}}
+- [{{ .Title }}]({{ .Permalink }}){{ with .Params.summary }}: {{ . }}{{ end }}
+{{ end -}}
+{{ end }}
+## Photos
+{{ range where .Site.RegularPages "Section" "photos" -}}
+- [{{ .Title }}]({{ .Permalink }})
+{{ end }}
+## Optional
+- [RSS feed]({{ "index.xml" | absURL }})
+- [JSON index]({{ "index.json" | absURL }})
+- [Tags]({{ "tags/" | absURL }})
+- [Sitemap]({{ "sitemap.xml" | absURL }})

--- a/layouts/home.llmsfull.txt
+++ b/layouts/home.llmsfull.txt
@@ -1,0 +1,41 @@
+{{- /* /llms-full.txt: every post and page inlined as markdown. */ -}}
+# {{ .Site.Title }}: full content
+
+> {{ .Site.Params.description }}
+
+This file inlines the raw markdown of every post and content page on {{ .Site.BaseURL }}. For a curated index see {{ "llms.txt" | absURL }}. Photos are listed in the index but omitted here (their bodies are metadata-only).
+
+Usage policy: search and user-triggered AI browsing are welcome; training use is not granted. See {{ "robots.txt" | absURL }} for the formal signal.
+
+{{ range where .Site.RegularPages "Section" "posts" }}
+---
+url: {{ .Permalink }}
+title: {{ .Title }}
+date: {{ .Date.Format "2006-01-02" }}
+{{- with .Params.tags }}
+tags: {{ delimit . ", " }}
+{{- end }}
+{{- with .Description }}
+description: {{ . }}
+{{- end }}
+---
+
+# {{ .Title }}
+
+{{ .RawContent }}
+{{ end }}
+{{- range where .Site.RegularPages "Section" "" }}
+{{- if not (in (slice "search" "archives") .File.ContentBaseName) }}
+---
+url: {{ .Permalink }}
+title: {{ .Title }}
+{{- with .Params.summary }}
+summary: {{ . }}
+{{- end }}
+---
+
+# {{ .Title }}
+
+{{ .RawContent }}
+{{ end -}}
+{{ end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,63 @@
+# gstv.io robots policy
+#
+# Stance: easy to cite, easy to browse, not a free-for-all training grant.
+# Machine-friendly index: {{ "llms.txt" | absURL }}
+# Full-content dump:     {{ "llms-full.txt" | absURL }}
+# Per-page raw markdown is available at <page>/index.md
+#
+# Content-Signal is an emerging Cloudflare-backed signal
+# (https://contentsignals.org). Not universally honored yet, but
+# stated here as the policy of record.
+
+User-agent: *
+Allow: /
+Content-Signal: search=yes, ai-input=yes, ai-train=no
+
+# Policy: normal search, AI input/retrieval, and user-triggered fetches are
+# allowed. Training, model development, and bulk data collection are not.
+# Some vendor controls bundle multiple uses; where no narrower training-only
+# control exists, this file chooses the training/data-collection opt-out.
+# Allowed by default includes Googlebot, Bingbot, Applebot, OAI-SearchBot,
+# ChatGPT-User, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User,
+# Meta-WebIndexer, Meta-ExternalFetcher, Amzn-SearchBot, and Amzn-User.
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: cohere-training-data-crawler
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Diffbot-User
+Allow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: omgili
+Disallow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/layouts/single.markdown.md
+++ b/layouts/single.markdown.md
@@ -1,0 +1,19 @@
+{{- /* Raw source markdown for a single page. */ -}}
+---
+url: {{ .Permalink }}
+title: {{ .Title }}
+{{- with .Date }}
+date: {{ .Format "2006-01-02" }}
+{{- end }}
+{{- with .Params.tags }}
+tags: {{ delimit . ", " }}
+{{- end }}
+{{- with .Description }}
+description: {{ . }}
+{{- end }}
+{{- with .Params.summary }}
+summary: {{ . }}
+{{- end }}
+---
+
+{{ .RawContent }}


### PR DESCRIPTION
## Summary

- Add Hugo outputs for `/llms.txt` and `/llms-full.txt`.
- Expose per-page raw markdown at `<page>/index.md`.
- Add a `robots.txt` template that allows search, AI input/retrieval, and user-triggered browsing while opting out of AI training, model development, and bulk data collection.
- Add `Amazonbot` to the opt-out list and explicitly allow `Diffbot-User` while keeping bulk `Diffbot` crawling blocked.
- Remove the stale `FacebookBot` block and use `cohere-training-data-crawler` instead of the weaker `cohere-ai` token.

## Security

- These outputs publish content that is already public on the site.
- This change adds no auth, user input handling, dynamic execution, or dependencies.
- `robots.txt` and `Content-Signal` are policy signals, not access control.

## Checks

- `just check`
- `bun audit`
